### PR TITLE
[travis] Disable PHP coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,16 +26,11 @@ before_script:
 
 script:
   # Run tests for the various components in parallel
-  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then ls -d tests/ZendTest/* | grep -v 'tests/ZendTest/_files' | grep -v 'tests/ZendTest/AllTests' | parallel --gnu -P 0 'echo "Running {} tests"; php ./vendor/bin/phpunit -c tests/phpunit.xml.dist --colors=always --coverage-php build/coverage/coverage-{/.}.cov {};' || exit 1; fi
+  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then ls -d tests/ZendTest/* | grep -v 'tests/ZendTest/_files' | grep -v 'tests/ZendTest/AllTests' | parallel --gnu -P 0 'echo "Running {} tests"; php ./vendor/bin/phpunit -c tests/phpunit.xml.dist --colors=always {};' || exit 1; fi
   - if [[ $TRAVIS_PHP_VERSION != '5.6' ]]; then ls -d tests/ZendTest/* | grep -v 'tests/ZendTest/_files' | grep -v 'tests/ZendTest/AllTests' | parallel --gnu -P 0 'echo "Running {} tests"; php ./vendor/bin/phpunit -c tests/phpunit.xml.dist --colors=always {};' || exit 1; fi
 
   # Run coding standard checks in parallel
   - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then ls -d library/Zend/* tests/ZendTest/* bin | parallel --gnu -P 0 'echo "Running {} CS checks"; php ./vendor/bin/php-cs-fixer fix {} -v --diff --dry-run --config-file=.php_cs;' || exit 1; fi
-
-after_script:
-  # Merges the individual clover reports of each component into a single clover.xml
-  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then php vendor/bin/phpcov merge --clover build/logs/clover.xml build/coverage; fi
-  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then php vendor/bin/coveralls; fi
 
 notifications:
   irc: "irc.freenode.org#zftalk.dev"


### PR DESCRIPTION
Disable test coverage due the high latency after merge https://github.com/zendframework/zf2/pull/7477

This won't be fixed since is expected to split the repository by components. These components will produce smaller test suites and won't require merge coverage reports.